### PR TITLE
Add float colors support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ profile
 doxygen/doc
 extras/Projucer/JUCECompileEngine.dylib
 Binaries/
-Builds/LinuxMakeFile/build
+Builds/LinuxMakefile/build
 Builds/LinuxMakefile/*\.AppDir/usr/bin/
 
 travis_enc.txt

--- a/Blux.jucer
+++ b/Blux.jucer
@@ -804,7 +804,7 @@
   <JUCEOPTIONS JUCE_STRICT_REFCOUNTEDPOINTER="1" ORGANICUI_USE_SERVUS="1" ORGANICUI_USE_WEBSERVER="1"
                JUCE_IP_AND_PORT_DETECTION="1" JUCE_EXCLUSIVE_BINDING_BY_DEFAULT="1"
                JUCE_ENABLE_BROADCAST_BY_DEFAULT="1" JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS="1"
-               JUCE_USE_WIN_WEBVIEW2="1"/>
+               JUCE_USE_WIN_WEBVIEW2="1" JUCE_FLOAT_COLOURS="1"/>
   <EXPORTFORMATS>
     <VS2022 targetFolder="Builds/VisualStudio2022" externalLibraries="Servus.lib&#10;dnssd.lib"
             smallIcon="kxAIe6" bigIcon="kxAIe6" extraCompilerFlags="/bigobj"


### PR DESCRIPTION
This PR depends on https://github.com/benkuper/JUCE/pull/1 and https://github.com/benkuper/juce_organicui/pull/34

This PR is enabling float colors support, nothing more is needed to make Blux work.
**NOTE:** @benkuper I have changed the jucer file but since this project doesn't use an `AppConfig.h` header unlike Chataigne, I'm unable to regenerate the Projucer project without breaking all the paths for the CI, so you will have to do it.