### PR TITLE
Remove check for same values when calculating effects blend

### DIFF
--- a/Source/Effect/Effect.cpp
+++ b/Source/Effect/Effect.cpp
@@ -140,11 +140,9 @@ void Effect::processComponent(Object* o, ObjectComponent* c, HashMap<Parameter*,
 		Parameter* cp = it.getKey();
 		var initVal = values[cp];
 		var val = it.getValue().clone();
-		if (initVal != val)
-		{
-			var bVal = blendValue(initVal, val, targetWeight);
-			values.set(cp, bVal);
-		}
+
+		var bVal = blendValue(initVal, val, targetWeight);
+		values.set(cp, bVal);
 
 		if (cp == vizComputedParamRef && vizParameter != nullptr && !vizParameter.wasObjectDeleted()) vizParameter->setValue(values[cp]);
 	}


### PR DESCRIPTION
As described on discord channel: https://discord.com/channels/899928319842197514/1369308004624891904/1369308004624891904

Basically, when combining 2 effects, one of them were being ignored if both had same value (2 overrides with add of value 0.5f resulted in 0.5f instead of 1.0f).

I'm sure this check was there for a reason, but I couldn't find why, opening it more for a discussion.